### PR TITLE
Skip malformed binding_partners and missing residues in pdbminer_complexes

### DIFF
--- a/aggregate/aggregate
+++ b/aggregate/aggregate
@@ -83,8 +83,6 @@ def process_pdbminer_data(data, final_df, target_column, interactor_column, stru
                     continue 
                 interactors.append(uniprot_id)
 
-        print (interactors)
-
         for interactor in interactors:
             # Check if the target and interactor exist in final_df:
             existing_row = final_df[
@@ -312,7 +310,6 @@ def main():
         interactor_column="Interactor_UniProt_AC", 
         structure_column="PDBminer_complexes_structure", 
         is_complexes=True
-
     )
 
     ## PROCESS PDBMINER ##
@@ -323,7 +320,6 @@ def main():
         interactor_column="Interactor_UniProt_AC", 
         structure_column="PDBminer_structure", 
         is_complexes=False
-
     )
     
     # Use user-specified filename or create default:

--- a/aggregate/aggregate
+++ b/aggregate/aggregate
@@ -51,9 +51,22 @@ def process_pdbminer_data(data, final_df, target_column, interactor_column, stru
             self_chain = row.get('self_chains', "").strip()
             target_uniprot_id = complex_details.get(self_chain, "")
 
-            # Only the binding_partners have passed the pdbminer_complexes filtering:
-            binding_partners = row.get('binding_partners', "").split(" residues binding ")
-            chain_1, chain_2 = binding_partners[0].strip(), binding_partners[1].strip()
+            # Skip rows with no binding residues
+            residues = str(row.get('residues', '')).strip()
+            if residues in ['', '[]']:
+                continue
+
+            binding_partners = str(row.get('binding_partners') or "").strip()
+
+            # Check binding_partners format
+            if " residues binding " not in binding_partners:
+                continue
+
+            parts = binding_partners.split(" residues binding ")
+            if len(parts) != 2:
+                continue
+
+            chain_1, chain_2 = parts[0].strip(), parts[1].strip()
             if chain_1 == self_chain:
                 interactors.append(complex_details.get(chain_2, ""))
             else:
@@ -69,6 +82,8 @@ def process_pdbminer_data(data, final_df, target_column, interactor_column, stru
                 if uniprot_id == target_uniprot_id:
                     continue 
                 interactors.append(uniprot_id)
+
+        print (interactors)
 
         for interactor in interactors:
             # Check if the target and interactor exist in final_df:
@@ -297,6 +312,7 @@ def main():
         interactor_column="Interactor_UniProt_AC", 
         structure_column="PDBminer_complexes_structure", 
         is_complexes=True
+
     )
 
     ## PROCESS PDBMINER ##
@@ -307,6 +323,7 @@ def main():
         interactor_column="Interactor_UniProt_AC", 
         structure_column="PDBminer_structure", 
         is_complexes=False
+
     )
     
     # Use user-specified filename or create default:


### PR DESCRIPTION
In this PR, crashes of aggregate (#58) were fixed, by:
- Adding check for valid "` residues binding` " format in `binding_partners` column of pdbminer_complexes
- Skipping rows where `residues` is empty or []

To test it, run aggregate on the example: `/data/user/shared_projects/mavisp/ATG12`:

- copy the `aggregate` folder in `/data/user/shared_projects/mavisp/ATG12/interactome`
- Inside `aggregate/`, run:
`./aggregate -m ../mentha2pdb_13062025/O94817.csv -s ../string2pdb/O94817_string_interactors.csv -p ../../structure_selection/pdbminer/results/O94817/O94817_all.csv -c ../../structure_selection/pdbminer_complexes/O94817_filtered.csv
`
